### PR TITLE
バイトコードの準拠バージョンをJava6にする

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.nablarch.framework'
-version = '1.0.1'
+version = '1.0.2'
 description = 'JAX-RS'
 
 buildscript {
@@ -28,8 +28,8 @@ apply plugin: 'idea'
 apply plugin: 'eclipse'
 
 // ビルド時のJavaバージョンを指定する
-sourceCompatibility=JavaVersion.VERSION_1_7
-targetCompatibility=JavaVersion.VERSION_1_7
+sourceCompatibility=JavaVersion.VERSION_1_6
+targetCompatibility=JavaVersion.VERSION_1_6
 
 configurations {
   integrationTest


### PR DESCRIPTION
バイトコードの準拠バージョンをJava6にする
#4
