### PR TITLE
HttpResponse.getContentTypeの挙動に振り回されないように修正

### DIFF
--- a/src/main/java/nablarch/fw/jaxrs/JaxRsResponseHandler.java
+++ b/src/main/java/nablarch/fw/jaxrs/JaxRsResponseHandler.java
@@ -95,7 +95,14 @@ public class JaxRsResponseHandler implements HttpRequestHandler {
         if (response.getContentLength() != null) {
             nativeResponse.setContentLength(Integer.parseInt(response.getContentLength()));
         }
-        nativeResponse.setContentType(response.getContentType());
+        // HttpResponse.getContentTypeはContent-Typeが設定されていない場合に
+        // text/plain;charset=UTF-8が設定されるようになっている。
+        // レスポンスボディがない場合はContent-Typeを設定する必要はないため、
+        // 自動的にデフォルト値が設定されてしまうHttpResponse.getContentTypeは使わない。
+        String contentType = response.getHeader("Content-Type");
+        if (contentType != null) {
+            nativeResponse.setContentType(contentType);
+        }
         for (Map.Entry<String, String> entry : response.getHeaderMap().entrySet()) {
             if (!entry.getKey().equals("Content-Length") && !entry.getKey().equals("Content-Type")) {
                 nativeResponse.setHeader(entry.getKey(), entry.getValue());

--- a/src/main/java/nablarch/fw/jaxrs/JaxRsResponseHandler.java
+++ b/src/main/java/nablarch/fw/jaxrs/JaxRsResponseHandler.java
@@ -42,6 +42,8 @@ public class JaxRsResponseHandler implements HttpRequestHandler {
     /** ロガー */
     private static final Logger LOGGER = LoggerManager.get(JaxRsResponseHandler.class);
 
+    private boolean useGetContentType;
+
     @Override
     public HttpResponse handle(HttpRequest request, ExecutionContext context) {
         HttpResponse response;
@@ -95,13 +97,18 @@ public class JaxRsResponseHandler implements HttpRequestHandler {
         if (response.getContentLength() != null) {
             nativeResponse.setContentLength(Integer.parseInt(response.getContentLength()));
         }
-        // HttpResponse.getContentTypeはContent-Typeが設定されていない場合に
-        // text/plain;charset=UTF-8が設定されるようになっている。
-        // レスポンスボディがない場合はContent-Typeを設定する必要はないため、
-        // 自動的にデフォルト値が設定されてしまうHttpResponse.getContentTypeは使わない。
-        String contentType = response.getHeader("Content-Type");
-        if (contentType != null) {
-            nativeResponse.setContentType(contentType);
+        if (useGetContentType) {
+            // Nablarch 5u17までの挙動を望む場合のため、フラグで選択できるようにする
+            nativeResponse.setContentType(response.getContentType());
+        } else {
+            // HttpResponse.getContentTypeはContent-Typeが設定されていない場合に
+            // text/plain;charset=UTF-8が設定されるようになっている。
+            // レスポンスボディがない場合はContent-Typeを設定する必要はないため、
+            // 自動的にデフォルト値が設定されてしまうHttpResponse.getContentTypeは使わない。
+            String contentType = response.getHeader("Content-Type");
+            if (contentType != null) {
+                nativeResponse.setContentType(contentType);
+            }
         }
         for (Map.Entry<String, String> entry : response.getHeaderMap().entrySet()) {
             if (!entry.getKey().equals("Content-Length") && !entry.getKey().equals("Content-Type")) {
@@ -155,6 +162,10 @@ public class JaxRsResponseHandler implements HttpRequestHandler {
      */
     public void setErrorLogWriter(final JaxRsErrorLogWriter errorLogWriter) {
         this.errorLogWriter = errorLogWriter;
+    }
+
+    public void setUseGetContentType(boolean useGetContentType) {
+        this.useGetContentType = useGetContentType;
     }
 }
 


### PR DESCRIPTION
`HttpResponse.getContentType`はヘッダーを格納する`Map`に`Content-Type`が設定されていない場合にデフォルト値として`text/plain;charset=UTF-8`を`put`するようになっています。
`204 No Content`のようにレスポンスボディが無いレスポンスの場合であっても例外ではなく、デフォルト値が設定されてしまいます。

そのため、自動的にデフォルト値が設定されてしまう`HttpResponse.getContentType`は使わずに`HttpResponse.getHeader`を使うようにしました。
この変更により、`Content-Type`が不要な場合は設定されずレスポンスが書き出されるようになりました。

なお、Nablarch 5u17までの挙動(自動的にデフォルト値が設定される挙動)を望む場合のため、`useGetContentType`フラグで挙動を選択できるようにしています。
