### PR TITLE
RESTにCORSの仕組みを追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ buildNumber.properties
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
 
+*.db

--- a/src/main/java/nablarch/fw/jaxrs/AdoptHandlerResponseFinisher.java
+++ b/src/main/java/nablarch/fw/jaxrs/AdoptHandlerResponseFinisher.java
@@ -1,0 +1,55 @@
+package nablarch.fw.jaxrs;
+
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpRequestHandler;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+
+/**
+ * {@link HttpRequestHandler}を{@link ResponseFinisher}として使用するクラス。
+ *
+ * このクラスで使用できる{@link HttpRequestHandler}は、自らレスポンスを作成せず、
+ * 後続ハンドラが返すレスポンスに変更を加えるハンドラに限定される。
+ *
+ * @author Kiyohito Itoh
+ */
+public class AdoptHandlerResponseFinisher implements ResponseFinisher {
+
+    /** ハンドラ */
+    private HttpRequestHandler handler;
+
+    /**
+     * ハンドラを設定する。
+     * @param handler ハンドラ
+     */
+    public void setHandler(HttpRequestHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public void finish(HttpRequest request, final HttpResponse response, ExecutionContext context) {
+        handler.handle(request, copy(context).addHandler(new HttpRequestHandler() {
+            @Override
+            public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+                return response;
+            }
+        }));
+    }
+
+    /**
+     * コンテキストをコピーする。
+     *
+     * リクエストスコープ、セッションスコープ、セッションストアがコピーされる。
+     *
+     * @param original コピー元のコンテキスト
+     * @return コピーされたコンテキスト
+     */
+    protected ExecutionContext copy(ExecutionContext original) {
+        ServletExecutionContext from = (ServletExecutionContext) original;
+        ServletExecutionContext to = new ServletExecutionContext(
+                from.getServletRequest(), from.getServletResponse(), from.getServletContext());
+        to.setSessionStoreMap(from.getSessionStoreMap());
+        return to;
+    }
+}

--- a/src/main/java/nablarch/fw/jaxrs/CorsPreflightRequestHandler.java
+++ b/src/main/java/nablarch/fw/jaxrs/CorsPreflightRequestHandler.java
@@ -1,0 +1,34 @@
+package nablarch.fw.jaxrs;
+
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.jaxrs.cors.BasicCors;
+import nablarch.fw.jaxrs.cors.Cors;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpRequestHandler;
+import nablarch.fw.web.HttpResponse;
+
+/**
+ * CORSのプリフライトリクエストを処理するハンドラ。
+ *
+ * @author Kiyohito Itoh
+ */
+public class CorsPreflightRequestHandler implements HttpRequestHandler {
+
+    private Cors cors = new BasicCors();
+
+    @Override
+    public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+        if (cors.isPreflightRequest(request, context)) {
+            return cors.createPreflightResponse(request, context);
+        }
+        return context.handleNext(request);
+    }
+
+    /**
+     * CORSの処理を行うインタフェースを設定する。
+     * @param cors CORSの処理を行うインタフェース
+     */
+    public void setCors(Cors cors) {
+        this.cors = cors;
+    }
+}

--- a/src/main/java/nablarch/fw/jaxrs/ResponseFinisher.java
+++ b/src/main/java/nablarch/fw/jaxrs/ResponseFinisher.java
@@ -1,5 +1,6 @@
 package nablarch.fw.jaxrs;
 
+import nablarch.core.util.annotation.Published;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.HttpResponse;
@@ -14,6 +15,7 @@ import nablarch.fw.web.HttpResponse;
  *
  * @author Kiyohito Itoh
  */
+@Published(tag = "architect")
 public interface ResponseFinisher {
     /**
      * レスポンスを仕上げる。

--- a/src/main/java/nablarch/fw/jaxrs/ResponseFinisher.java
+++ b/src/main/java/nablarch/fw/jaxrs/ResponseFinisher.java
@@ -1,0 +1,26 @@
+package nablarch.fw.jaxrs;
+
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpResponse;
+
+/**
+ * レスポンスを仕上げるインタフェース。
+ *
+ * {@link JaxRsResponseHandler}が作成したレスポンス(エラーレスポンス含む)に共通する処理を行う。
+ * 共通処理としてはセキュリティやCORSに対応したレスポンスヘッダの設定などを想定している。
+ *
+ * レスポンスの作成処理の後に実行する処理のため、このインタフェースの実装クラスでは例外を発生させてはならない。
+ *
+ * @author Kiyohito Itoh
+ */
+public interface ResponseFinisher {
+    /**
+     * レスポンスを仕上げる。
+     *
+     * @param request リクエスト
+     * @param response レスポンス
+     * @param context コンテキスト
+     */
+    void finish(HttpRequest request, HttpResponse response, ExecutionContext context);
+}

--- a/src/main/java/nablarch/fw/jaxrs/cors/BasicCors.java
+++ b/src/main/java/nablarch/fw/jaxrs/cors/BasicCors.java
@@ -20,7 +20,7 @@ public class BasicCors implements Cors {
     private static final Logger LOGGER = LoggerManager.get(Cors.class);
 
     private List<String> allowOrigins = null;
-    private String allowMethods = joinWithComma(Arrays.asList("OPTIONS", "GET", "POST", "PUT", "DELETE"));
+    private String allowMethods = joinWithComma(Arrays.asList("OPTIONS", "GET", "POST", "PUT", "DELETE", "PATCH"));
     private String allowHeaders = joinWithComma(Arrays.asList("Content-Type", "X-CSRF-TOKEN"));
     private long maxAge = -1;
     private boolean allowCredentials = true;

--- a/src/main/java/nablarch/fw/jaxrs/cors/BasicCors.java
+++ b/src/main/java/nablarch/fw/jaxrs/cors/BasicCors.java
@@ -1,0 +1,132 @@
+package nablarch.fw.jaxrs.cors;
+
+import nablarch.core.log.Logger;
+import nablarch.core.log.LoggerManager;
+import nablarch.core.util.StringUtil;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpResponse;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * {@link Cors}の基本実装クラス。
+ *
+ * @author Kiyohito Itoh
+ */
+public class BasicCors implements Cors {
+
+    private static final Logger LOGGER = LoggerManager.get(Cors.class);
+
+    private List<String> allowOrigins = null;
+    private String allowMethods = joinWithComma(Arrays.asList("OPTIONS", "GET", "POST", "PUT", "DELETE"));
+    private String allowHeaders = joinWithComma(Arrays.asList("Content-Type", "X-CSRF-TOKEN"));
+    private long maxAge = -1;
+    private boolean allowCredentials = true;
+
+    @Override
+    public boolean isPreflightRequest(HttpRequest request, ExecutionContext context) {
+        return request.getMethod().equals("OPTIONS") &&
+                request.getHeader(Headers.ORIGIN) != null &&
+                request.getHeader(Headers.ACCESS_CONTROL_REQUEST_METHOD) != null &&
+                request.getHeader(Headers.ACCESS_CONTROL_REQUEST_HEADERS) != null;
+    }
+
+    @Override
+    public HttpResponse createPreflightResponse(HttpRequest request, ExecutionContext context) {
+        if (LOGGER.isDebugEnabled()) {
+            String message = String.format("Preflight request%nRequest-Path: %s%n%s: %s%n%s: %s%n%s: %s",
+                    request.getRequestPath(),
+                    Headers.ORIGIN, request.getHeader(Headers.ORIGIN),
+                    Headers.ACCESS_CONTROL_REQUEST_METHOD, request.getHeader(Headers.ACCESS_CONTROL_REQUEST_METHOD),
+                    Headers.ACCESS_CONTROL_REQUEST_HEADERS, request.getHeader(Headers.ACCESS_CONTROL_REQUEST_HEADERS));
+            LOGGER.logDebug(message);
+        }
+        HttpResponse response = new HttpResponse(204);
+        response.setHeader(Headers.ACCESS_CONTROL_ALLOW_METHODS, allowMethods);
+        response.setHeader(Headers.ACCESS_CONTROL_ALLOW_HEADERS, allowHeaders);
+        response.setHeader(Headers.ACCESS_CONTROL_MAX_AGE, String.valueOf(maxAge));
+        postProcess(request, response, context);
+        return response;
+    }
+
+    @Override
+    public void postProcess(HttpRequest request, HttpResponse response, ExecutionContext context) {
+        processOrigin(request, response);
+        processCredentials(response);
+    }
+
+    private void processOrigin(HttpRequest request, HttpResponse response) {
+        if (allowOrigins == null) {
+            throw new IllegalStateException("The allowOrigins property of CORS must be set.");
+        }
+        String origin = request.getHeader(Headers.ORIGIN);
+        if (allowOrigins.contains(origin)) {
+            response.setHeader(Headers.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+            response.setHeader(Headers.VARY, Headers.ORIGIN);
+        }
+    }
+
+    private void processCredentials(HttpResponse response) {
+        if (allowCredentials) {
+            response.setHeader(Headers.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+        }
+    }
+
+    private static String joinWithComma(List<String> collection) {
+        return StringUtil.join(", ", collection);
+    }
+
+    /**
+     * リソースへのアクセスを許可するオリジンを設定する。
+     * @param allowOrigins リソースへのアクセスを許可するオリジン
+     */
+    public void setAllowOrigins(List<String> allowOrigins) {
+        this.allowOrigins = allowOrigins;
+    }
+
+    /**
+     * リソースへのアクセス時に許可するメソッドを設定する。
+     * @param allowMethods リソースへのアクセス時に許可するメソッド
+     */
+    public void setAllowMethods(List<String> allowMethods) {
+        this.allowMethods = joinWithComma(allowMethods);
+    }
+
+    /**
+     * 実際のリクエストで使用できるHTTPヘッダを設定する。
+     * @param allowHeaders 実際のリクエストで使用できるHTTPヘッダ
+     */
+    public void setAllowHeaders(List<String> allowHeaders) {
+        this.allowHeaders = joinWithComma(allowHeaders);
+    }
+
+    /**
+     * プリフライトリクエストの結果をキャッシュしてよい時間（秒）を設定する。
+     * @param maxAge プリフライトリクエストの結果をキャッシュしてよい時間（秒）
+     */
+    public void setMaxAge(long maxAge) {
+        this.maxAge = maxAge;
+    }
+
+    /**
+     * 実際のリクエストで資格情報を使用してよいか否かを設定する。
+     * @param allowCredentials 実際のリクエストで資格情報を使用してよい場合はtrue
+     */
+    public void setAllowCredentials(boolean allowCredentials) {
+        this.allowCredentials = allowCredentials;
+    }
+
+    private static final class Headers {
+        static final String ORIGIN = "Origin";
+        static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
+        static final String ACCESS_CONTROL_REQUEST_HEADERS = "Access-Control-Request-Headers";
+        static final String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
+        static final String ACCESS_CONTROL_ALLOW_METHODS = "Access-Control-Allow-Methods";
+        static final String ACCESS_CONTROL_ALLOW_HEADERS = "Access-Control-Allow-Headers";
+        static final String ACCESS_CONTROL_MAX_AGE = "Access-Control-Max-Age";
+        static final String ACCESS_CONTROL_ALLOW_CREDENTIALS = "Access-Control-Allow-Credentials";
+        static final String VARY = "Vary";
+    }
+}

--- a/src/main/java/nablarch/fw/jaxrs/cors/Cors.java
+++ b/src/main/java/nablarch/fw/jaxrs/cors/Cors.java
@@ -1,0 +1,38 @@
+package nablarch.fw.jaxrs.cors;
+
+import nablarch.core.util.annotation.Published;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpResponse;
+
+/**
+ * CORSの処理を行うインタフェース。
+ *
+ * @author Kiyohito Itoh
+ */
+@Published(tag = "architect")
+public interface Cors {
+    /**
+     * リクエストがプリフライトリクエストであるか否かを判定する。
+     * @param request リクエスト
+     * @param context コンテキスト
+     * @return リクエストがプリフライトリクエストの場合はtrue
+     */
+    boolean isPreflightRequest(HttpRequest request, ExecutionContext context);
+
+    /**
+     * プリフライトリクエストに対するレスポンスを作成する。
+     * @param request リクエスト
+     * @param context コンテキスト
+     * @return プリフライトリクエストに対するレスポンス
+     */
+    HttpResponse createPreflightResponse(HttpRequest request, ExecutionContext context);
+
+    /**
+     * プリフライトリクエスト後の実際のリクエストのレスポンスに対する処理を行う。
+     * @param request リクエスト
+     * @param context コンテキスト
+     * @param response レスポンス
+     */
+    void postProcess(HttpRequest request, HttpResponse response, ExecutionContext context);
+}

--- a/src/main/java/nablarch/fw/jaxrs/cors/CorsResponseFinisher.java
+++ b/src/main/java/nablarch/fw/jaxrs/cors/CorsResponseFinisher.java
@@ -1,0 +1,29 @@
+package nablarch.fw.jaxrs.cors;
+
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.jaxrs.ResponseFinisher;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpResponse;
+
+/**
+ * 実際のリクエストに対するレスポンスにCORSのレスポンスヘッダを設定するクラス。
+ *
+ * @author Kiyohito Itoh
+ */
+public class CorsResponseFinisher implements ResponseFinisher {
+
+    private Cors cors = new BasicCors();
+
+    @Override
+    public void finish(HttpRequest request, HttpResponse response, ExecutionContext context) {
+        cors.postProcess(request, response, context);
+    }
+
+    /**
+     * CORSの処理を行うインタフェースを設定する。
+     * @param cors CORSの処理を行うインタフェース
+     */
+    public void setCors(Cors cors) {
+        this.cors = cors;
+    }
+}

--- a/src/test/java/nablarch/fw/jaxrs/AdoptHandlerResponseFinisherTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/AdoptHandlerResponseFinisherTest.java
@@ -1,0 +1,66 @@
+package nablarch.fw.jaxrs;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.web.handler.SecureHandler;
+import nablarch.fw.web.handler.secure.ContentTypeOptionsHeader;
+import nablarch.fw.web.handler.secure.ReferrerPolicyHeader;
+import nablarch.fw.web.handler.secure.XssProtectionHeader;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+import org.junit.Test;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+
+/**
+ * {@link AdoptHandlerResponseFinisher}のテスト。
+ */
+public class AdoptHandlerResponseFinisherTest {
+
+    @Mocked
+    private HttpServletRequest mockServletRequest;
+
+    @Mocked
+    private HttpServletResponse mockServletResponse;
+
+    @Mocked
+    private ServletContext mockServletContext;
+
+    @Test
+    public void testSecureHandler() {
+
+        new Expectations() {{
+            mockServletRequest.getContextPath();
+            result = "dummy";
+            mockServletRequest.getRequestURI();
+            result = "dummy/test";
+        }};
+
+        SecureHandler handler = new SecureHandler();
+        handler.setSecureResponseHeaderList(Arrays.asList(
+                new XssProtectionHeader(),
+                new ContentTypeOptionsHeader(),
+                new ReferrerPolicyHeader()));
+
+        AdoptHandlerResponseFinisher sut = new AdoptHandlerResponseFinisher();
+        sut.setHandler(handler);
+
+        HttpRequest request = null;
+        HttpResponse response = new HttpResponse();
+        ExecutionContext context = new ServletExecutionContext(
+                mockServletRequest, mockServletResponse, mockServletContext);
+        sut.finish(request, response, context);
+
+        assertThat(response.getHeader("X-XSS-Protection"), notNullValue());
+        assertThat(response.getHeader("X-Content-Type-Options"), notNullValue());
+        assertThat(response.getHeader("Referrer-Policy"), notNullValue());
+    }
+}

--- a/src/test/java/nablarch/fw/jaxrs/CorsPreflightRequestHandlerTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/CorsPreflightRequestHandlerTest.java
@@ -1,0 +1,70 @@
+package nablarch.fw.jaxrs;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.jaxrs.cors.Cors;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpRequestHandler;
+import nablarch.fw.web.HttpResponse;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * {@link CorsPreflightRequestHandler}のテスト。
+ */
+public class CorsPreflightRequestHandlerTest {
+
+    @Mocked
+    private Cors cors;
+
+    @Test
+    public void preflightRequest() {
+
+        final ExecutionContext context = new ExecutionContext();
+        final HttpRequest request = null;
+
+        new Expectations() {{
+            cors.isPreflightRequest(request, context);
+            result = true;
+            cors.createPreflightResponse(request, context);
+            result = new HttpResponse(204);
+        }};
+
+        CorsPreflightRequestHandler sut = new CorsPreflightRequestHandler();
+        sut.setCors(cors);
+
+        context.addHandler(sut);
+        HttpResponse response = context.handleNext(request);
+
+        assertThat(response.getStatusCode(), is(204));
+    }
+
+    @Test
+    public void notPreflightRequest() {
+
+        final ExecutionContext context = new ExecutionContext();
+        final HttpRequest request = null;
+
+        new Expectations() {{
+            cors.isPreflightRequest(request, context);
+            result = false;
+        }};
+
+        CorsPreflightRequestHandler sut = new CorsPreflightRequestHandler();
+        sut.setCors(cors);
+
+        context.addHandler(sut)
+                .addHandler(new HttpRequestHandler() {
+                    @Override
+                    public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+                        return new HttpResponse(404);
+                    }
+                });
+        HttpResponse response = context.handleNext(request);
+
+        assertThat(response.getStatusCode(), is(404));
+    }
+}

--- a/src/test/java/nablarch/fw/jaxrs/cors/BasicCorsTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/cors/BasicCorsTest.java
@@ -1,0 +1,185 @@
+package nablarch.fw.jaxrs.cors;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpResponse;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+/**
+ * {@link BasicCors}のテスト。
+ */
+public class BasicCorsTest {
+
+    @Mocked
+    private HttpRequest request;
+
+    /**
+     * リソースへのアクセスを許可するオリジンが設定されていない場合は、
+     *　設定するように伝える実行時例外が送出されること。
+     */
+    @Test
+    public void requiredSetting() {
+
+        new Expectations() {{
+            request.getHeader("Origin");
+            result = "https://foo.example";
+            request.getHeader("Access-Control-Request-Method");
+            result = "POST";
+            request.getHeader("Access-Control-Request-Headers");
+            result = "TEST";
+        }};
+
+        BasicCors sut = new BasicCors();
+        try {
+            sut.createPreflightResponse(request, null);
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage(), is("The allowOrigins property of CORS must be set."));
+        }
+    }
+
+    /**
+     * デフォルト設定を確認するテスト。
+     */
+    @Test
+    public void defaultSettings() {
+
+        new Expectations() {{
+            request.getHeader("Origin");
+            result = "https://foo.example";
+            request.getHeader("Access-Control-Request-Method");
+            result = "POST";
+            request.getHeader("Access-Control-Request-Headers");
+            result = "TEST";
+        }};
+
+        BasicCors sut = new BasicCors();
+        sut.setAllowOrigins(Arrays.asList("https://foo.example"));
+        HttpResponse response = sut.createPreflightResponse(request, null);
+
+        assertThat(response.getStatusCode(), is(204));
+        assertThat(response.getHeader("Access-Control-Allow-Methods"),
+                is("OPTIONS, GET, POST, PUT, DELETE"));
+        assertThat(response.getHeader("Access-Control-Allow-Headers"),
+                is("Content-Type, X-CSRF-TOKEN"));
+        assertThat(response.getHeader("Access-Control-Max-Age"), is("-1"));
+        assertThat(response.getHeader("Access-Control-Allow-Origin"), is("https://foo.example"));
+        assertThat(response.getHeader("Vary"), is("Origin"));
+        assertThat(response.getHeader("Access-Control-Allow-Credentials"), is("true"));
+    }
+
+    /**
+     * カスタム設定を確認するテスト。
+     */
+    @Test
+    public void customSettings() {
+        new Expectations() {{
+            request.getHeader("Origin");
+            result = "https://foo.example";
+            request.getHeader("Access-Control-Request-Method");
+            result = "POST";
+            request.getHeader("Access-Control-Request-Headers");
+            result = "TEST";
+        }};
+
+        BasicCors sut = new BasicCors();
+        sut.setAllowOrigins(Arrays.asList("https://foo.example"));
+        sut.setAllowCredentials(false);
+        sut.setAllowHeaders(Arrays.asList("TEST", "TEST2"));
+        sut.setAllowMethods(Arrays.asList("GET", "POST"));
+        sut.setMaxAge(60);
+        HttpResponse response = sut.createPreflightResponse(request, null);
+
+        assertThat(response.getStatusCode(), is(204));
+        assertThat(response.getHeader("Access-Control-Allow-Methods"), is("GET, POST"));
+        assertThat(response.getHeader("Access-Control-Allow-Headers"), is("TEST, TEST2"));
+        assertThat(response.getHeader("Access-Control-Max-Age"), is("60"));
+        assertThat(response.getHeader("Access-Control-Allow-Origin"), is("https://foo.example"));
+        assertThat(response.getHeader("Vary"), is("Origin"));
+        assertThat(response.getHeader("Access-Control-Allow-Credentials"), is(nullValue()));
+    }
+
+    /**
+     * 許可しないオリジンからのリクエストの場合は
+     * Access-Control-Allow-OriginヘッダとVaryヘッダが設定されないこと。
+     */
+    @Test
+    public void requestsFromDisallowedOrigin() {
+
+        new Expectations() {{
+            request.getHeader("Origin");
+            result = "https://bar.example";
+            request.getHeader("Access-Control-Request-Method");
+            result = "POST";
+            request.getHeader("Access-Control-Request-Headers");
+            result = "TEST";
+        }};
+
+        BasicCors sut = new BasicCors();
+        sut.setAllowOrigins(Arrays.asList("https://foo.example"));
+        HttpResponse response = sut.createPreflightResponse(request, null);
+
+        assertThat(response.getStatusCode(), is(204));
+        assertThat(response.getHeader("Access-Control-Allow-Methods"),
+                is("OPTIONS, GET, POST, PUT, DELETE"));
+        assertThat(response.getHeader("Access-Control-Allow-Headers"),
+                is("Content-Type, X-CSRF-TOKEN"));
+        assertThat(response.getHeader("Access-Control-Max-Age"), is("-1"));
+        assertThat(response.getHeader("Access-Control-Allow-Origin"), is(nullValue()));
+        assertThat(response.getHeader("Vary"), is(nullValue()));
+        assertThat(response.getHeader("Access-Control-Allow-Credentials"), is("true"));
+    }
+
+    /**
+     * プリフライトリクエスト判定のテスト。
+     */
+    @Test
+    public void isPreflightRequestForMethodNG() {
+        new Expectations() {{
+            request.getMethod();                                 result = "GET";
+        }};
+        assertThat(new BasicCors().isPreflightRequest(request, null), is(false));
+    }
+    @Test
+    public void isPreflightRequestForOriginNG() {
+        new Expectations() {{
+            request.getMethod();                                 result = "OPTIONS";
+            request.getHeader("Origin");                         result = null;
+        }};
+        assertThat(new BasicCors().isPreflightRequest(request, null), is(false));
+    }
+    @Test
+    public void isPreflightRequestForAccessControlRequestMethodNG() {
+        new Expectations() {{
+            request.getMethod();                                 result = "OPTIONS";
+            request.getHeader("Origin");                         result = "OK";
+            request.getHeader("Access-Control-Request-Method");  result = null;
+        }};
+        assertThat(new BasicCors().isPreflightRequest(request, null), is(false));
+    }
+    @Test
+    public void isPreflightRequestForAccessControlRequestHeadersNG() {
+        new Expectations() {{
+            request.getMethod();                                 result = "OPTIONS";
+            request.getHeader("Origin");                         result = "OK";
+            request.getHeader("Access-Control-Request-Method");  result = "OK";
+            request.getHeader("Access-Control-Request-Headers"); result = null;
+        }};
+        assertThat(new BasicCors().isPreflightRequest(request, null), is(false));
+    }
+    @Test
+    public void isPreflightRequestForAllOK() {
+        new Expectations() {{
+            request.getMethod();                                 result = "OPTIONS";
+            request.getHeader("Origin");                         result = "OK";
+            request.getHeader("Access-Control-Request-Method");  result = "OK";
+            request.getHeader("Access-Control-Request-Headers"); result = "OK";
+        }};
+        assertThat(new BasicCors().isPreflightRequest(request, null), is(true));
+    }
+}

--- a/src/test/java/nablarch/fw/jaxrs/cors/BasicCorsTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/cors/BasicCorsTest.java
@@ -64,7 +64,7 @@ public class BasicCorsTest {
 
         assertThat(response.getStatusCode(), is(204));
         assertThat(response.getHeader("Access-Control-Allow-Methods"),
-                is("OPTIONS, GET, POST, PUT, DELETE"));
+                is("OPTIONS, GET, POST, PUT, DELETE, PATCH"));
         assertThat(response.getHeader("Access-Control-Allow-Headers"),
                 is("Content-Type, X-CSRF-TOKEN"));
         assertThat(response.getHeader("Access-Control-Max-Age"), is("-1"));
@@ -126,7 +126,7 @@ public class BasicCorsTest {
 
         assertThat(response.getStatusCode(), is(204));
         assertThat(response.getHeader("Access-Control-Allow-Methods"),
-                is("OPTIONS, GET, POST, PUT, DELETE"));
+                is("OPTIONS, GET, POST, PUT, DELETE, PATCH"));
         assertThat(response.getHeader("Access-Control-Allow-Headers"),
                 is("Content-Type, X-CSRF-TOKEN"));
         assertThat(response.getHeader("Access-Control-Max-Age"), is("-1"));

--- a/src/test/java/nablarch/fw/jaxrs/cors/CorsResponseFinisherTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/cors/CorsResponseFinisherTest.java
@@ -1,0 +1,37 @@
+package nablarch.fw.jaxrs.cors;
+
+import mockit.Mocked;
+import mockit.Verifications;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpResponse;
+import org.junit.Test;
+
+/**
+ * {@link CorsResponseFinisher}のテスト。
+ */
+public class CorsResponseFinisherTest {
+
+    @Mocked
+    private Cors cors;
+
+    /**
+     * CORSに処理を委譲していることを確認。
+     */
+    @Test
+    public void delegate() {
+
+        final HttpRequest request = null;
+        final HttpResponse response = new HttpResponse();
+        final ExecutionContext context = new ExecutionContext();
+
+        CorsResponseFinisher sut = new CorsResponseFinisher();
+        sut.setCors(cors);
+        sut.finish(request, response, context);
+
+        new Verifications() {{
+            cors.postProcess(request, response, context);
+            times=1;
+        }};
+    }
+}


### PR DESCRIPTION
https://nablarch.atlassian.net/browse/NAB-377
上記に対応しました。

JaxRsResponseHandlerで作成されたレスポンスに変更を加えるポイントとしてResponseFinisherを追加しました。
CORSはプリフライトリクエストはハンドラで、実際のリクエストへのCORSのレスポンス処理はResponseFinisherで行うようにしました。

SecureHandlerのようなレスポンスヘッダを設定しているだけのハンドラをResponseFinisherとして再利用できるようにAdoptHandlerResponseFinisherを追加しています。