### PR TITLE
feat: リソースクラスとメソッドをリクエストスコープに保存するように修正

### DIFF
--- a/src/main/java/nablarch/fw/jaxrs/JaxRsMethodBinder.java
+++ b/src/main/java/nablarch/fw/jaxrs/JaxRsMethodBinder.java
@@ -211,6 +211,7 @@ public class JaxRsMethodBinder implements MethodBinder<HttpRequest, Object> {
             final Handler<HttpRequest, Object> handler = new Handler<HttpRequest, Object>() {
                 @Override
                 public Object handle(final HttpRequest req, final ExecutionContext ctx) {
+                    saveBoundClassAndMethodToRequestScope(ctx, boundMethod.getDeclaringClass(), boundMethod);
                     return resourceMethod.invoke(delegate, req, ctx);
                 }
             };

--- a/src/main/java/nablarch/fw/jaxrs/JaxRsMethodBinder.java
+++ b/src/main/java/nablarch/fw/jaxrs/JaxRsMethodBinder.java
@@ -211,7 +211,7 @@ public class JaxRsMethodBinder implements MethodBinder<HttpRequest, Object> {
             final Handler<HttpRequest, Object> handler = new Handler<HttpRequest, Object>() {
                 @Override
                 public Object handle(final HttpRequest req, final ExecutionContext ctx) {
-                    saveBoundClassAndMethodToRequestScope(ctx, boundMethod.getDeclaringClass(), boundMethod);
+                    saveBoundClassAndMethodToRequestScope(ctx, delegate.getClass(), boundMethod);
                     return resourceMethod.invoke(delegate, req, ctx);
                 }
             };

--- a/src/test/java/nablarch/fw/jaxrs/JaxRsMethodBinderTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/JaxRsMethodBinderTest.java
@@ -290,6 +290,16 @@ public class JaxRsMethodBinderTest {
         assertThat(method, is(nothingMethod));
     }
 
+    @Test
+    public void testBind_delegateObjectClassIsSetToScopeAsBoundClass() {
+        sut = new JaxRsMethodBinder("nothing", dummyHandlers);
+        HandlerWrapper<HttpRequest, Object> wrapper = sut.bind(new TestSubAction());
+        wrapper.handle(req, ctx);
+
+        Class<?> clazz = ctx.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS);
+        assertThat(clazz, is((Object)TestSubAction.class));
+    }
+
     /**
      * テスト用のActionクラス。
      */
@@ -355,7 +365,9 @@ public class JaxRsMethodBinderTest {
         public void interceptorTest() {
         }
     }
-    
+
+    private static class TestSubAction extends TestAction {}
+
     @Interceptor(TestInterceptor.Impl.class)
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)

--- a/src/test/java/nablarch/fw/jaxrs/JaxRsMethodBinderTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/JaxRsMethodBinderTest.java
@@ -10,6 +10,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -273,6 +274,20 @@ public class JaxRsMethodBinderTest {
         final HttpResponse result = (HttpResponse) wrapper.handle(req, new ExecutionContext());
         
         assertThat("Interceptorで設定した値が戻されること", result.getContentPath().getPath(), is("TestInterceptorの戻り"));
+    }
+
+    @Test
+    public void testBind_resourceClassAndMethodAreSavedInRequestScope() throws Exception {
+        sut = new JaxRsMethodBinder("nothing", dummyHandlers);
+        HandlerWrapper<HttpRequest, Object> wrapper = sut.bind(new TestAction());
+        wrapper.handle(req, ctx);
+
+        Class<?> clazz = ctx.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS);
+        assertThat(clazz, is((Object)TestAction.class));
+
+        Method method = ctx.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD);
+        Method nothingMethod = TestAction.class.getMethod("nothing");
+        assertThat(method, is(nothingMethod));
     }
 
     /**


### PR DESCRIPTION
下記Micrometerアダプタの修正で必要になる修正です。
https://github.com/nablarch/nablarch-micrometer-adaptor/pull/5

`JaxRsMethodBinding` で、クラスとメソッドの情報をリクエストスコープに保存するようにする修正を入れています。

下記 nablarch-fw のPRで `MethodBinding` で同様の修正を入れていますが、 `JaxRsMethodBinding` は `handle(HttpRequest, ExecutionContext)` メソッドをオーバーライドして独自に実装しているため、個別の修正が必要になります。
https://github.com/nablarch/nablarch-fw/pull/10
