### PR TITLE
「ボディを持たないレスポンスでもContent-Typeを設定するか否か」の処理をnablarch-fw-webに移動することに伴う修正

### DIFF
--- a/src/main/java/nablarch/fw/jaxrs/JaxRsResponseHandler.java
+++ b/src/main/java/nablarch/fw/jaxrs/JaxRsResponseHandler.java
@@ -119,7 +119,10 @@ public class JaxRsResponseHandler implements HttpRequestHandler {
         if (response.getContentLength() != null) {
             nativeResponse.setContentLength(Integer.parseInt(response.getContentLength()));
         }
-        nativeResponse.setContentType(response.getContentType());
+        String contentType = response.getContentType();
+        if (contentType != null) {
+            nativeResponse.setContentType(response.getContentType());
+        }
         for (Map.Entry<String, String> entry : response.getHeaderMap().entrySet()) {
             if (!entry.getKey().equals("Content-Length") && !entry.getKey().equals("Content-Type")) {
                 nativeResponse.setHeader(entry.getKey(), entry.getValue());

--- a/src/main/java/nablarch/fw/jaxrs/JaxRsResponseHandler.java
+++ b/src/main/java/nablarch/fw/jaxrs/JaxRsResponseHandler.java
@@ -47,9 +47,6 @@ public class JaxRsResponseHandler implements HttpRequestHandler {
     /** ロガー */
     private static final Logger LOGGER = LoggerManager.get(JaxRsResponseHandler.class);
 
-    /** ボディを持たないレスポンスでもContent-Typeを設定するか否か */
-    private boolean setContentTypeForResponseWithNoBody = false;
-
     @Override
     public HttpResponse handle(HttpRequest request, ExecutionContext context) {
         HttpResponse response;
@@ -122,19 +119,7 @@ public class JaxRsResponseHandler implements HttpRequestHandler {
         if (response.getContentLength() != null) {
             nativeResponse.setContentLength(Integer.parseInt(response.getContentLength()));
         }
-        if (setContentTypeForResponseWithNoBody) {
-            // Nablarch 5u17までの挙動を望む場合のため、フラグで選択できるようにする
-            nativeResponse.setContentType(response.getContentType());
-        } else {
-            // HttpResponse.getContentTypeはContent-Typeが設定されていない場合に
-            // text/plain;charset=UTF-8が設定されるようになっている。
-            // レスポンスボディがない場合はContent-Typeを設定する必要はないため、
-            // 自動的にデフォルト値が設定されてしまうHttpResponse.getContentTypeは使わない。
-            String contentType = response.getHeader("Content-Type");
-            if (contentType != null) {
-                nativeResponse.setContentType(contentType);
-            }
-        }
+        nativeResponse.setContentType(response.getContentType());
         for (Map.Entry<String, String> entry : response.getHeaderMap().entrySet()) {
             if (!entry.getKey().equals("Content-Length") && !entry.getKey().equals("Content-Type")) {
                 nativeResponse.setHeader(entry.getKey(), entry.getValue());
@@ -195,17 +180,6 @@ public class JaxRsResponseHandler implements HttpRequestHandler {
      */
     public void setResponseFinishers(List<ResponseFinisher> responseFinishers) {
         this.responseFinishers = responseFinishers;
-    }
-
-    /**
-     * ボディを持たないレスポンスでもContent-Typeを設定するか否かを設定する。
-     *
-     * デフォルトはfalse。
-     *
-     * @param setContentTypeForResponseWithNoBody ボディを持たないレスポンスでもContent-Typeを設定する場合はtrue
-     */
-    public void setSetContentTypeForResponseWithNoBody(boolean setContentTypeForResponseWithNoBody) {
-        this.setContentTypeForResponseWithNoBody = setContentTypeForResponseWithNoBody;
     }
 }
 

--- a/src/test/java/nablarch/fw/jaxrs/BodyConvertHandlerTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/BodyConvertHandlerTest.java
@@ -178,7 +178,7 @@ public class BodyConvertHandlerTest {
         assertThat(response, isStatusCode(505).withBody("TestForm:0")); // not counted up
         assertThat(testBodyConverter.readCount, is(0));
         assertThat(testBodyConverter.writeCount, is(1));
-        assertThat(response.getHeaderMap().size(), is(2));
+        assertThat(response.getHeaderMap().size(), is(3));
         assertThat(response.getHeader("test-name"), is("test-value"));
     }
 
@@ -259,7 +259,7 @@ public class BodyConvertHandlerTest {
         assertThat(response, isStatusCode(202).withBody("TestForm:0")); // not counted up
         assertThat(testBodyConverter.readCount, is(0));
         assertThat(testBodyConverter.writeCount, is(1));
-        assertThat(response.getHeaderMap().size(), is(1));
+        assertThat(response.getHeaderMap().size(), is(2));
     }
 
     /**

--- a/src/test/java/nablarch/fw/jaxrs/BodyConvertHandlerTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/BodyConvertHandlerTest.java
@@ -178,7 +178,7 @@ public class BodyConvertHandlerTest {
         assertThat(response, isStatusCode(505).withBody("TestForm:0")); // not counted up
         assertThat(testBodyConverter.readCount, is(0));
         assertThat(testBodyConverter.writeCount, is(1));
-        assertThat(response.getHeaderMap().size(), is(3));
+        assertThat(response.getHeaderMap().size(), is(2));
         assertThat(response.getHeader("test-name"), is("test-value"));
     }
 
@@ -259,7 +259,7 @@ public class BodyConvertHandlerTest {
         assertThat(response, isStatusCode(202).withBody("TestForm:0")); // not counted up
         assertThat(testBodyConverter.readCount, is(0));
         assertThat(testBodyConverter.writeCount, is(1));
-        assertThat(response.getHeaderMap().size(), is(2));
+        assertThat(response.getHeaderMap().size(), is(1));
     }
 
     /**

--- a/src/test/java/nablarch/fw/jaxrs/JaxRsResponseHandlerTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/JaxRsResponseHandlerTest.java
@@ -153,7 +153,7 @@ public class JaxRsResponseHandlerTest {
         }};
 
         final WebConfig webConfig = new WebConfig();
-        webConfig.setContentTypeForResponseWithNoBodyEnabled(true);
+        webConfig.setAddDefaultContentTypeForNoBodyResponse(true);
         SystemRepository.load(new ObjectLoader() {
             @Override
             public Map<String, Object> load() {

--- a/src/test/java/nablarch/fw/jaxrs/JaxRsResponseHandlerTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/JaxRsResponseHandlerTest.java
@@ -125,48 +125,6 @@ public class JaxRsResponseHandlerTest {
         new Verifications() {{
             // servlet responseに201ステータスコードが設定されていること
             mockServletResponse.setStatus(201);
-
-            mockServletResponse.setContentType(null); times=0;
-        }};
-    }
-
-    /**
-     * ボディを持たないレスポンスでもContent-Typeを設定する場合のテスト。
-     * <p/>
-     * HttpResponse.getContentTypeはContent-Typeが設定されていない場合に
-     * text/plain;charset=UTF-8が設定されるようになっている。
-     * text/plain;charset=UTF-8が設定されること。
-     */
-    @Test
-    public void testStatusCodeOnlyResponseWithSetContentTypeForResponseWithNoBody() throws Exception {
-        // -------------------------------------------------- setup
-        context.addHandler(new Handler<Object, Object>() {
-            @Override
-            public Object handle(Object o, ExecutionContext context) {
-                return new HttpResponse(HttpResponse.Status.CREATED.getStatusCode());
-            }
-        });
-        new Expectations() {{
-            mockHttpRequest.getMethod();
-            result = "GET";
-            mockHttpRequest.getRequestUri();
-            result = "/api/user";
-        }};
-
-        // -------------------------------------------------- execute
-        sut.setSetContentTypeForResponseWithNoBody(true);
-        HttpResponse response = sut.handle(mockHttpRequest, context);
-        sut.setSetContentTypeForResponseWithNoBody(false);
-
-        // -------------------------------------------------- assert
-        assertThat("201でボディが空のHttpResponseが戻される", response, isStatusCode(201).withEmptyBody());
-        assertThat("ServletOutputStreamに書き込まれたボティの長さも0であること",
-                getBodyString(), is(""));
-        new Verifications() {{
-            // servlet responseに201ステータスコードが設定されていること
-            mockServletResponse.setStatus(201);
-
-            mockServletResponse.setContentType("text/plain;charset=UTF-8");
         }};
     }
 
@@ -602,8 +560,6 @@ public class JaxRsResponseHandlerTest {
         new Verifications() {{
             // servlet responseに201ステータスコードが設定されていること
             mockServletResponse.setStatus(201);
-
-            mockServletResponse.setContentType(null); times=0;
         }};
     }
 


### PR DESCRIPTION
## 背景
https://github.com/nablarch/nablarch-fw-web/pull/92 の対応に伴い、本モジュールから「ボディを持たないレスポンスでもContent-Typeを設定するか否か」を判定し処理する機能を削除

## やったこと
- https://github.com/nablarch/nablarch-fw-jaxrs/pull/13 で加えた機能を削除。
  https://github.com/nablarch/nablarch-fw-web/pull/92 の変更に合わせてユニットテストを修正。

## 確認したこと
  - https://github.com/nablarch/nablarch-fw-web/pull/92 を取り込んだ状態でユニットが成功すること。