### PR TITLE
プリフライトリクエストの判定条件からAccess-Control-Request-Headersを除外

### DIFF
--- a/src/main/java/nablarch/fw/jaxrs/cors/BasicCors.java
+++ b/src/main/java/nablarch/fw/jaxrs/cors/BasicCors.java
@@ -29,8 +29,7 @@ public class BasicCors implements Cors {
     public boolean isPreflightRequest(HttpRequest request, ExecutionContext context) {
         return request.getMethod().equals("OPTIONS") &&
                 request.getHeader(Headers.ORIGIN) != null &&
-                request.getHeader(Headers.ACCESS_CONTROL_REQUEST_METHOD) != null &&
-                request.getHeader(Headers.ACCESS_CONTROL_REQUEST_HEADERS) != null;
+                request.getHeader(Headers.ACCESS_CONTROL_REQUEST_METHOD) != null;
     }
 
     @Override

--- a/src/test/java/nablarch/fw/jaxrs/cors/BasicCorsTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/cors/BasicCorsTest.java
@@ -168,7 +168,6 @@ public class BasicCorsTest {
             request.getMethod();                                 result = "OPTIONS";
             request.getHeader("Origin");                         result = "OK";
             request.getHeader("Access-Control-Request-Method");  result = "OK";
-            request.getHeader("Access-Control-Request-Headers"); result = null;
         }};
         assertThat(new BasicCors().isPreflightRequest(request, null), is(true));
     }
@@ -178,7 +177,6 @@ public class BasicCorsTest {
             request.getMethod();                                 result = "OPTIONS";
             request.getHeader("Origin");                         result = "OK";
             request.getHeader("Access-Control-Request-Method");  result = "OK";
-            request.getHeader("Access-Control-Request-Headers"); result = "OK";
         }};
         assertThat(new BasicCors().isPreflightRequest(request, null), is(true));
     }

--- a/src/test/java/nablarch/fw/jaxrs/cors/BasicCorsTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/cors/BasicCorsTest.java
@@ -163,15 +163,6 @@ public class BasicCorsTest {
         assertThat(new BasicCors().isPreflightRequest(request, null), is(false));
     }
     @Test
-    public void isPreflightRequestForAccessControlRequestHeadersLessOK() {
-        new Expectations() {{
-            request.getMethod();                                 result = "OPTIONS";
-            request.getHeader("Origin");                         result = "OK";
-            request.getHeader("Access-Control-Request-Method");  result = "OK";
-        }};
-        assertThat(new BasicCors().isPreflightRequest(request, null), is(true));
-    }
-    @Test
     public void isPreflightRequestForAllOK() {
         new Expectations() {{
             request.getMethod();                                 result = "OPTIONS";

--- a/src/test/java/nablarch/fw/jaxrs/cors/BasicCorsTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/cors/BasicCorsTest.java
@@ -163,14 +163,14 @@ public class BasicCorsTest {
         assertThat(new BasicCors().isPreflightRequest(request, null), is(false));
     }
     @Test
-    public void isPreflightRequestForAccessControlRequestHeadersNG() {
+    public void isPreflightRequestForAccessControlRequestHeadersLessOK() {
         new Expectations() {{
             request.getMethod();                                 result = "OPTIONS";
             request.getHeader("Origin");                         result = "OK";
             request.getHeader("Access-Control-Request-Method");  result = "OK";
             request.getHeader("Access-Control-Request-Headers"); result = null;
         }};
-        assertThat(new BasicCors().isPreflightRequest(request, null), is(false));
+        assertThat(new BasicCors().isPreflightRequest(request, null), is(true));
     }
     @Test
     public void isPreflightRequestForAllOK() {


### PR DESCRIPTION
一部のプリフライトリクエストで判定がうまくいかず通常リクエスト扱いとなってしまった。

リクエストボディが無い DELETE リクエスト等では Content-Type も設定されないため、リクエスト時のヘッダが空になるケースがあり、そのような場合は Access-Control-Request-Headers もヘッダには設定されないことがある。（プリフライトリクエストはブラウザの実装依存で送信される）

nablarch.fw.jaxrs.cors.BasicCors ではプリフライトリクエストであるかの判定に、ヘッダに Access-Control-Request-Headers が設定されていることが必須という条件があるため、前述のケースではプリフライトリクエストとして判定されない。

このためプリフライトリクエストの判定から Access-Control-Request-Headers が存在するという条件を除外し以下の条件で判定するように変更。

- HTTPメソッド：OPSTIONS
- Originヘッダ：存在する
- Access-Control-Request-Methodヘッダ：存在する