### PR TITLE
プリフライトリクエストの判定条件からAccess-Control-Request-Headersを除外

### DIFF
--- a/src/main/java/nablarch/fw/jaxrs/cors/BasicCors.java
+++ b/src/main/java/nablarch/fw/jaxrs/cors/BasicCors.java
@@ -29,8 +29,7 @@ public class BasicCors implements Cors {
     public boolean isPreflightRequest(HttpRequest request, ExecutionContext context) {
         return request.getMethod().equals("OPTIONS") &&
                 request.getHeader(Headers.ORIGIN) != null &&
-                request.getHeader(Headers.ACCESS_CONTROL_REQUEST_METHOD) != null &&
-                request.getHeader(Headers.ACCESS_CONTROL_REQUEST_HEADERS) != null;
+                request.getHeader(Headers.ACCESS_CONTROL_REQUEST_METHOD) != null;
     }
 
     @Override

--- a/src/test/java/nablarch/fw/jaxrs/cors/BasicCorsTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/cors/BasicCorsTest.java
@@ -163,22 +163,11 @@ public class BasicCorsTest {
         assertThat(new BasicCors().isPreflightRequest(request, null), is(false));
     }
     @Test
-    public void isPreflightRequestForAccessControlRequestHeadersNG() {
-        new Expectations() {{
-            request.getMethod();                                 result = "OPTIONS";
-            request.getHeader("Origin");                         result = "OK";
-            request.getHeader("Access-Control-Request-Method");  result = "OK";
-            request.getHeader("Access-Control-Request-Headers"); result = null;
-        }};
-        assertThat(new BasicCors().isPreflightRequest(request, null), is(false));
-    }
-    @Test
     public void isPreflightRequestForAllOK() {
         new Expectations() {{
             request.getMethod();                                 result = "OPTIONS";
             request.getHeader("Origin");                         result = "OK";
             request.getHeader("Access-Control-Request-Method");  result = "OK";
-            request.getHeader("Access-Control-Request-Headers"); result = "OK";
         }};
         assertThat(new BasicCors().isPreflightRequest(request, null), is(true));
     }


### PR DESCRIPTION
#20をリリースブランチに取り込む