### PR TITLE
test: Java 17 用のプロファイルを追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,13 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>java17</id>
+      <properties>
+        <!-- Arquillian のテストで使用する AP サーバー(glassfish)を動かすために必要 -->
+        <junit.additionalArgLine>--add-opens java.base/java.lang=ALL-UNNAMED</junit.additionalArgLine>
+      </properties>
+    </profile>
   </profiles>
 
   <dependencies>


### PR DESCRIPTION
テストで使用している Arquillian が起動する GlassFish が内部に持っている JAXB が古く、実行時に内部APIにリフレクションでアクセスしようとしてエラーになる。

JAXB の依存を直接指定できれば jaxb-impl を2.3.5 に上げることでエラーを回避できるが、問題が発生しているのは GlassFish が内部に持っているモノなので切り替え不可。
そのため、 JUnit 実行時の JVM 引数に `--add-opens` を追加することで対応した。

```log
Stacktrace was: java.lang.NoClassDefFoundError: Could not initialize class com.sun.xml.bind.v2.runtime.reflect.opt.Injector
```