### PR TITLE
H2更新にあわせてテーブル定義を修正

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,6 @@
     <dependency>
       <groupId>com.nablarch.integration</groupId>
       <artifactId>nablarch-jersey-adaptor</artifactId>
-      <version>LATEST</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/src/test/java/nablarch/fw/jaxrs/integration/app/IntegrationTestResource.java
+++ b/src/test/java/nablarch/fw/jaxrs/integration/app/IntegrationTestResource.java
@@ -37,7 +37,7 @@ public class IntegrationTestResource extends ExternalResource {
     private void createTestTable() {
         System.out.println("create person table");
         SqlPStatement statement = connection.prepareStatement(
-                "create table  if not exists  person (id IDENTITY , name varchar(100) not null, PRIMARY KEY (id))");
+                "create table if not exists person (id integer generated always as identity primary key, name varchar(100) not null)");
         statement.execute();
         statement.close();
         connection.commit();


### PR DESCRIPTION
nablarch-parentに定義したH2のバージョンを1.4から2系に更新したところ以下の問題を検知したため修正しました。

- 本来bomで管理されるNablarchモジュールのバージョンが個別のpom.xmlに記載されており、さらにLATESTというメタバージョンになっている。
  - LATEST指定を削除しbomで指定されたバージョンが使用されるよう修正
- create table文でカラム定義にIDENTITY型が使用されているが、H2の2系ではIDENTITY型はサポートされていない。
  - 標準的な記法である`generated always as identity`を使用するよう修正（H2の1.4でもサポートされている）