### PR TITLE
公開APIを追加

### DIFF
--- a/src/main/java/nablarch/fw/jaxrs/BodyConvertHandler.java
+++ b/src/main/java/nablarch/fw/jaxrs/BodyConvertHandler.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import nablarch.core.log.Logger;
 import nablarch.core.log.LoggerManager;
 import nablarch.core.util.StringUtil;
+import nablarch.core.util.annotation.Published;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.web.HttpErrorResponse;
 import nablarch.fw.web.HttpRequest;
@@ -20,6 +21,7 @@ import nablarch.fw.web.HttpResponse.Status;
  *
  * @author Kiyohito Itoh
  */
+@Published(tag = "architect")
 public class BodyConvertHandler implements HttpRequestHandler {
 
     /** ロガー */

--- a/src/main/java/nablarch/fw/jaxrs/BodyConvertHandler.java
+++ b/src/main/java/nablarch/fw/jaxrs/BodyConvertHandler.java
@@ -85,7 +85,7 @@ public class BodyConvertHandler implements HttpRequestHandler {
 
     /**
      * {@link EntityResponse}からコンバートされた{@link HttpResponse}にコピーする。
-     *
+     * <p>
      * レスポンスヘッダとステータスコードをコピーする。
      * レスポンスヘッダは上書きしない。
      * ステータスコードは指定された場合のみコピーする。
@@ -111,7 +111,7 @@ public class BodyConvertHandler implements HttpRequestHandler {
 
     /**
      * メディアタイプを変換するための{@link BodyConverter}を取得する。
-     *
+     * <p>
      * 変換対象の{@link BodyConverter}が存在しない場合は、{@link Status#UNSUPPORTED_MEDIA_TYPE}を持つ{@link HttpErrorResponse}を送出する。
      *
      * @param mediaType メディアタイプ
@@ -147,7 +147,7 @@ public class BodyConvertHandler implements HttpRequestHandler {
 
     /**
      * HTTPヘッダーのContent-Typeに指定されたメディアタイプをサポートしているかを判定する。
-     *
+     * <p>
      * 以下の場合のみサポートしていると判定する。
      * <pre>
      * ・Content-Typeが指定され、かつメディアタイプと一致する場合。（GET以外の場合を想定）
@@ -168,7 +168,7 @@ public class BodyConvertHandler implements HttpRequestHandler {
 
     /**
      * {@link BodyConverter}のリストを設定する。
-     *
+     * <p>
      * 既に設定されていた{@link BodyConverter}のリストは破棄される。
      *
      * @param bodyConverters {@link BodyConverter}

--- a/src/main/java/nablarch/fw/jaxrs/BodyConverter.java
+++ b/src/main/java/nablarch/fw/jaxrs/BodyConverter.java
@@ -1,5 +1,6 @@
 package nablarch.fw.jaxrs;
 
+import nablarch.core.util.annotation.Published;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.HttpResponse;
@@ -9,6 +10,7 @@ import nablarch.fw.web.HttpResponse;
  *
  * @author Naoki Yamamoto
  */
+@Published(tag = "architect")
 public interface BodyConverter {
 
     /**

--- a/src/main/java/nablarch/fw/jaxrs/FormUrlEncodedConverter.java
+++ b/src/main/java/nablarch/fw/jaxrs/FormUrlEncodedConverter.java
@@ -1,6 +1,7 @@
 package nablarch.fw.jaxrs;
 
 import nablarch.core.beans.BeanUtil;
+import nablarch.core.util.annotation.Published;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.HttpResponse;
@@ -18,6 +19,7 @@ import java.util.Map;
  *
  * @author Kiyohito Itoh
  */
+@Published(tag = "architect")
 public class FormUrlEncodedConverter extends BodyConverterSupport {
 
     @Override

--- a/src/main/java/nablarch/fw/jaxrs/FormUrlEncodedConverter.java
+++ b/src/main/java/nablarch/fw/jaxrs/FormUrlEncodedConverter.java
@@ -76,7 +76,7 @@ public class FormUrlEncodedConverter extends BodyConverterSupport {
     }
 
     /**
-     * レスポンスオブジェクトを{@link MultivaluedMap<String, String>}にキャストする。
+     * レスポンスオブジェクトを{@link MultivaluedMap}にキャストする。
      * <p>
      * キャストできない場合は{@link IllegalStateException}をスローする。
      *
@@ -84,6 +84,7 @@ public class FormUrlEncodedConverter extends BodyConverterSupport {
      * @param context {@link JaxRsContext}
      * @return キャスト後のオブジェクト
      */
+    @SuppressWarnings("unchecked")
     private MultivaluedMap<String, String> castResponse(Object response, JaxRsContext context) {
         try {
             return (MultivaluedMap<String, String>) response;

--- a/src/main/java/nablarch/fw/jaxrs/FormUrlEncodedConverter.java
+++ b/src/main/java/nablarch/fw/jaxrs/FormUrlEncodedConverter.java
@@ -70,14 +70,14 @@ public class FormUrlEncodedConverter extends BodyConverterSupport {
     private String encode(String str, Charset encoding) {
         try {
             return URLEncoder.encode(str, encoding.name());
-        } catch (UnsupportedEncodingException ignore) {
-            throw new RuntimeException(ignore); // not happened.
+        } catch (UnsupportedEncodingException uee) {
+            throw new RuntimeException(uee); // not happened.
         }
     }
 
     /**
      * レスポンスオブジェクトを{@link MultivaluedMap<String, String>}にキャストする。
-     *
+     * <p>
      * キャストできない場合は{@link IllegalStateException}をスローする。
      *
      * @param response レスポンスオブジェクト

--- a/src/main/java/nablarch/fw/jaxrs/JaxRsBeanValidationHandler.java
+++ b/src/main/java/nablarch/fw/jaxrs/JaxRsBeanValidationHandler.java
@@ -5,6 +5,7 @@ import javax.validation.groups.ConvertGroup;
 import javax.validation.groups.Default;
 
 import nablarch.core.message.ApplicationException;
+import nablarch.core.util.annotation.Published;
 import nablarch.core.validation.ee.ValidatorUtil;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.Handler;
@@ -21,6 +22,7 @@ import nablarch.fw.web.HttpRequest;
  *
  * @author Hisaaki Shioiri
  */
+@Published(tag = "architect")
 public class JaxRsBeanValidationHandler implements Handler<HttpRequest, Object> {
 
     @Override


### PR DESCRIPTION
以下のクラスは、[解説書](https://nablarch.github.io/docs/LATEST/doc/application_framework/adaptors/jaxrs_adaptor.html#id9)で案内されている`JaxRsHandlerListFactory`の実装時に再利用したいクラスだが、公開APIとなっていなかったため、アーキテクト向けの公開APIとしました。

- `BodyConverterHandler`
- `JaxRsBeanValidationHandler`
- `FormUrlEncodedConverter`

また、`BodyConverter`について、実装クラスの`BodyConverterSupport`が公開APIであるため、インタフェースも公開が妥当と判断し、アーキテクト向けの公開APIとしました。