### PR TITLE
リソースクラスがインターフェースを実装、もしくは親クラスを継承することをサポートする

### DIFF
--- a/src/main/java/nablarch/fw/jaxrs/JaxRsMethodBinder.java
+++ b/src/main/java/nablarch/fw/jaxrs/JaxRsMethodBinder.java
@@ -228,10 +228,10 @@ public class JaxRsMethodBinder implements MethodBinder<HttpRequest, Object> {
             if (isJaxRsResourceClass(clazz)) {
                 return clazz;
             }
-
+            // 親クラスを優先して探索する
             Class<?> superClass = clazz.getSuperclass();
-            if (!superClass.equals(Object.class)) {
-                return findJaxRsResourceClass(superClass);
+            if (isJaxRsResourceClass(superClass)) {
+                return superClass;
             }
 
             // インタフェースを検索する
@@ -239,6 +239,10 @@ public class JaxRsMethodBinder implements MethodBinder<HttpRequest, Object> {
                 if (isJaxRsResourceClass(interfaceClass)) {
                     return interfaceClass;
                 }
+            }
+
+            if (!superClass.equals(Object.class)) {
+                return findJaxRsResourceClass(superClass);
             }
 
             return null;

--- a/src/main/java/nablarch/fw/jaxrs/JaxRsMethodBinder.java
+++ b/src/main/java/nablarch/fw/jaxrs/JaxRsMethodBinder.java
@@ -2,7 +2,9 @@ package nablarch.fw.jaxrs;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import jakarta.ws.rs.Path;
@@ -188,13 +190,21 @@ public class JaxRsMethodBinder implements MethodBinder<HttpRequest, Object> {
             Method method = null;
 
             Class<?> resourceClass = findJaxRsResourceClass(delegate.getClass());
+            Method[] methods;
 
-            if (resourceClass == null) {
+            if (resourceClass != null) {
+                // JAX-RSリソースクラスの場合は、そのクラスにのみ定義されたpublicメソッドを対象とする
+                methods =
+                        Arrays.stream(resourceClass.getDeclaredMethods())
+                                .filter(m -> Modifier.isPublic(m.getModifiers()))
+                                .toArray(Method[]::new);
+            } else {
                 // @Pathアノテーションが付与されたリソースクラスではない場合は、delegateに指定されたクラスをそのまま使用する
                 resourceClass = delegate.getClass();
+                methods = resourceClass.getMethods();
             }
 
-            for (Method m : resourceClass.getMethods()) {
+            for (Method m : methods) {
                 if (!m.getName().equals(methodName)) {
                     continue;
                 }

--- a/src/test/java/nablarch/fw/jaxrs/JaxRsMethodBinderTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/JaxRsMethodBinderTest.java
@@ -120,6 +120,16 @@ public class JaxRsMethodBinderTest {
         assertThat("インターフェース定義を実装したメソッドが実行されていること", ((HttpResponse) wrapper.handle(req, ctx)).getBodyString(), containsString("ok"));
 
         sut = new JaxRsMethodBinder("list", dummyHandlers);
+        wrapper = sut.bind(new ResourceExtendsAndImplements());
+        assertThat("戻り値の型がMethodBindingを継承していること", wrapper, instanceOf(MethodBinding.class));
+        assertThat("インターフェース定義を実装したメソッドが実行されていること", ((HttpResponse) wrapper.handle(req, ctx)).getBodyString(), containsString("ok"));
+
+        sut = new JaxRsMethodBinder("list", dummyHandlers);
+        wrapper = sut.bind(new ResourceExtendsAndImplements2());
+        assertThat("戻り値の型がMethodBindingを継承していること", wrapper, instanceOf(MethodBinding.class));
+        assertThat("親クラスで実装したメソッドが実行されていること", ((HttpResponse) wrapper.handle(req, ctx)).getBodyString(), containsString("ok"));
+
+        sut = new JaxRsMethodBinder("list", dummyHandlers);
         wrapper = sut.bind(new ResourceInheritDefaultMethod());
         assertThat("戻り値の型がMethodBindingを継承していること", wrapper, instanceOf(MethodBinding.class));
         assertThat("引き継いだデフォルトメソッドが実行されていること", ((HttpResponse) wrapper.handle(req, ctx)).getBodyString(), containsString("ok"));
@@ -457,6 +467,24 @@ public class JaxRsMethodBinderTest {
         HttpResponse list();
     }
 
+    public static abstract class ParentPlainClass {
+    }
+
+    public static abstract class ParentPlainExtendsClass extends ParentPlainClass {
+    }
+
+    @Path("/path2")
+    public static abstract class ParentResource {
+        @GET
+        @Path("/list2")
+        @Produces(MediaType.APPLICATION_JSON)
+        public HttpResponse list() {
+            HttpResponse response = new HttpResponse(200);
+            response.write("ok");
+            return response;
+        }
+    }
+
     public static class ResourceImpl implements ResourceInterface {
         @Override
         public HttpResponse list() {
@@ -464,6 +492,18 @@ public class JaxRsMethodBinderTest {
             response.write("ok");
             return response;
         }
+    }
+
+    public static class ResourceExtendsAndImplements extends ParentPlainExtendsClass implements ResourceInterface {
+        @Override
+        public HttpResponse list() {
+            HttpResponse response = new HttpResponse(200);
+            response.write("ok");
+            return response;
+        }
+    }
+
+    public static class ResourceExtendsAndImplements2 extends ParentResource implements ResourceInterface {
     }
 
     @Path("/path")

--- a/src/test/java/nablarch/fw/jaxrs/JaxRsMethodBinderTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/JaxRsMethodBinderTest.java
@@ -1,5 +1,9 @@
 package nablarch.fw.jaxrs;
 
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.Handler;
 import nablarch.fw.HandlerWrapper;
@@ -97,6 +101,33 @@ public class JaxRsMethodBinderTest {
         assertThat("戻り値の型がMethodBindingを継承していること", wrapper, instanceOf(MethodBinding.class));
         assertThat("指定したメソッドが実行されていること", ((HttpResponse) wrapper.handle(req, ctx)).getBodyString(),
                 containsString("request and context and form"));
+    }
+
+    /**
+     * JAX-RSリソースクラスの継承、インターフェース実装に関する呼び分けを確認する
+     */
+    @Test
+    public void testBind_jaxRsInheritVariation_success() throws Exception {
+
+        sut = new JaxRsMethodBinder("list", dummyHandlers);
+        HandlerWrapper<HttpRequest, Object> wrapper = sut.bind(new SimpleResource());
+        assertThat("戻り値の型がMethodBindingを継承していること", wrapper, instanceOf(MethodBinding.class));
+        assertThat("指定したメソッドが実行されていること", ((HttpResponse) wrapper.handle(req, ctx)).getBodyString(), containsString("ok"));
+
+        sut = new JaxRsMethodBinder("list", dummyHandlers);
+        wrapper = sut.bind(new ResourceImpl());
+        assertThat("戻り値の型がMethodBindingを継承していること", wrapper, instanceOf(MethodBinding.class));
+        assertThat("インターフェース定義を実装したメソッドが実行されていること", ((HttpResponse) wrapper.handle(req, ctx)).getBodyString(), containsString("ok"));
+
+        sut = new JaxRsMethodBinder("list", dummyHandlers);
+        wrapper = sut.bind(new ResourceInheritDefaultMethod());
+        assertThat("戻り値の型がMethodBindingを継承していること", wrapper, instanceOf(MethodBinding.class));
+        assertThat("引き継いだデフォルトメソッドが実行されていること", ((HttpResponse) wrapper.handle(req, ctx)).getBodyString(), containsString("ok"));
+
+        sut = new JaxRsMethodBinder("list", dummyHandlers);
+        wrapper = sut.bind(new ResourceOverrideDefaultMethod());
+        assertThat("戻り値の型がMethodBindingを継承していること", wrapper, instanceOf(MethodBinding.class));
+        assertThat("オーバーライドしたメソッドが実行されていること", ((HttpResponse) wrapper.handle(req, ctx)).getBodyString(), containsString("test"));
     }
 
     /**
@@ -402,6 +433,60 @@ public class JaxRsMethodBinderTest {
         @SuppressWarnings("SameReturnValue")
         private HttpResponse method() {
             return null;
+        }
+    }
+
+
+    @Path("/path")
+    public static class SimpleResource {
+        @GET
+        @Path("/list")
+        @Produces(MediaType.TEXT_PLAIN)
+        public HttpResponse list() {
+            HttpResponse response = new HttpResponse(200);
+            response.write("ok");
+            return response;
+        }
+    }
+
+    @Path("/path")
+    public interface ResourceInterface {
+        @GET
+        @Path("/list")
+        @Produces(MediaType.APPLICATION_JSON)
+        HttpResponse list();
+    }
+
+    public static class ResourceImpl implements ResourceInterface {
+        @Override
+        public HttpResponse list() {
+            HttpResponse response = new HttpResponse(200);
+            response.write("ok");
+            return response;
+        }
+    }
+
+    @Path("/path")
+    public interface ResourceDefaultMethodInterface {
+        @GET
+        @Path("/list")
+        @Produces(MediaType.APPLICATION_JSON)
+        default HttpResponse list() {
+            HttpResponse response = new HttpResponse(200);
+            response.write("ok");
+            return response;
+        }
+    }
+
+    public static class ResourceInheritDefaultMethod implements ResourceDefaultMethodInterface {
+    }
+
+    public static class ResourceOverrideDefaultMethod implements ResourceDefaultMethodInterface {
+        @Override
+        public HttpResponse list() {
+            HttpResponse response = new HttpResponse(200);
+            response.write("test");
+            return response;
         }
     }
 }


### PR DESCRIPTION
https://github.com/nablarch/nablarch-router-adaptor/pull/23 の対。

Actionクラスに対する呼び出しを行った時に、サブクラスで実装をオーバーライドしている時に実クラスのメソッドを参照してしまい、JAX-RSアノテーションの定義が行われているリソースクラスのメソッドを参照していなかったため、こちらも`@Path`が設定されているクラスをさかのぼるように修正に修正しました。

`@Path`アノテーションが付与されているクラスが見つからなかった場合は、これまでと同じ処理になるようにフォールバックします。