### PR TITLE
EntityResponseをジェネリクスに対応

### DIFF
--- a/src/main/java/nablarch/fw/jaxrs/BodyConvertHandler.java
+++ b/src/main/java/nablarch/fw/jaxrs/BodyConvertHandler.java
@@ -57,7 +57,7 @@ public class BodyConvertHandler implements HttpRequestHandler {
             return new HttpResponse(Status.NO_CONTENT.getStatusCode());
         }
 
-        final EntityResponse entityResponse = response instanceof EntityResponse ? (EntityResponse) response : null;
+        final EntityResponse<?> entityResponse = response instanceof EntityResponse<?> ? (EntityResponse<?>) response : null;
         final Object entity = entityResponse != null ? entityResponse.getEntity() : response;
 
         String producesMediaType = jaxRsContext.getProducesMediaType();
@@ -93,7 +93,7 @@ public class BodyConvertHandler implements HttpRequestHandler {
      * @param from {@link EntityResponse}
      * @param to コンバートされた{@link HttpResponse}
      */
-    private void copy(EntityResponse from, HttpResponse to) {
+    private void copy(EntityResponse<?> from, HttpResponse to) {
 
         // response header
         final Map<String, String> toHeaderMap = to.getHeaderMap();

--- a/src/main/java/nablarch/fw/jaxrs/EntityResponse.java
+++ b/src/main/java/nablarch/fw/jaxrs/EntityResponse.java
@@ -5,16 +5,17 @@ import nablarch.fw.web.HttpResponse;
 
 /**
  * Entityを持つレスポンス。
- *
+ * <p>
  * {@link jakarta.ws.rs.Produces}を使用した場合に
  * レスポンスヘッダとステータスコードを指定したい場合に使用する。
  *
+ * @param <E> Entityの型
  * @author Kiyohito Itoh
  */
-public class EntityResponse extends HttpResponse {
+public class EntityResponse<E> extends HttpResponse {
 
     /** エンティティ */
-    private Object entity;
+    private E entity;
 
     /** ステータスコードが設定されたか否か */
     private boolean statusCodeSet = false;
@@ -24,7 +25,7 @@ public class EntityResponse extends HttpResponse {
      *
      * @return エンティティ
      */
-    public Object getEntity() {
+    public E getEntity() {
         return entity;
     }
 
@@ -34,7 +35,7 @@ public class EntityResponse extends HttpResponse {
      * @param entity エンティティ
      */
     @Published
-    public EntityResponse setEntity(Object entity) {
+    public EntityResponse<E> setEntity(E entity) {
         this.entity = entity;
         return this;
     }

--- a/src/test/java/nablarch/fw/jaxrs/BodyConvertHandlerTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/BodyConvertHandlerTest.java
@@ -631,16 +631,16 @@ public class BodyConvertHandlerTest {
         }
 
         @Produces(MediaType.APPLICATION_XML)
-        public EntityResponse entityResponse(HttpRequest request) {
-            EntityResponse response = new EntityResponse();
+        public EntityResponse<TestForm> entityResponse(HttpRequest request) {
+            EntityResponse<TestForm> response = new EntityResponse<>();
             response.setEntity(new TestForm());
             response.setStatusCode(505);
             response.setHeader("test-name", "test-value");
             return response;
         }
 
-        public EntityResponse entityResponseWithContentType(HttpRequest request) {
-            EntityResponse response = new EntityResponse();
+        public EntityResponse<TestForm> entityResponseWithContentType(HttpRequest request) {
+            EntityResponse<TestForm> response = new EntityResponse<>();
             response.setEntity(new TestForm());
             response.setContentType(MediaType.APPLICATION_JSON);
             response.setStatusCode(505);
@@ -649,14 +649,15 @@ public class BodyConvertHandlerTest {
         }
 
         @Produces(MediaType.APPLICATION_XML)
-        public EntityResponse invalidContentType(HttpRequest request) {
-            EntityResponse response = new EntityResponse();
+        public EntityResponse<?> invalidContentType(HttpRequest request) {
+            EntityResponse<?> response = new EntityResponse<>();
             response.setContentType(MediaType.APPLICATION_JSON);
             return response;
         }
 
         @Produces(MediaType.APPLICATION_XML)
         public EntityResponse entityResponseNoneSpecified(HttpRequest request) {
+            // 以前はEntityResponseがジェネリクスに対応していなかったため、互確認のために残している
             EntityResponse response = new EntityResponse();
             response.setEntity(new TestForm());
             return response;


### PR DESCRIPTION
# 変更内容

`EntityResponse`をジェネリクスに対応させ、型を指定できるように改善する。

以下の点を変更。

- `EntityResponse`の型定義に型パラメータを指定
- `EntityResponse#setEntity`、`EntityResponse#getEntity`の引数、戻り値の型に反映
- `EntityResponse`の利用箇所を型指定またはワイルドカードを使用するよう修正

# 変更による影響範囲

既存の`EntityResponse`、`EntityResponse#setEntity`、`EntityResponse#getEntity`を使用している個所でコンパイル時にraw型を使用していると警告が出るようになる。

機能自体に影響はない。

# 備考

`EntityResponse#setContentType`と`@Produces`の両方を指定すると、`BodyConvertHandler`がどちらかを指定すべきと例外をスローする。

https://github.com/nablarch/nablarch-fw-jaxrs/blob/2.2.0/src/main/java/nablarch/fw/jaxrs/BodyConvertHandler.java#L63-L73

`EntityResponse#setContentType`のみとすると、`BodyConvertHandler`は通過するが各メディアタイプ向けに実装されている`BodyConverter`は`@Produces`のみを期待しており、実質`@Produces`のみしか使用できないことが動作確認中に発見。

このため、`BodyConvertHandler`がスローする例外メッセージと辻褄が合わない。

これを修正するには、各メディアタイプを担当している`BodyConverter`を修正してまわる必要があるが、解説書を見るとそもそも`@Produces`のみを使用し`EntityResponse#setContentType`は使わないことを想定しているように見えるので今回はこのままにした。

> フレームワークではProducesアノテーションを使用した場合にレスポンスヘッダとステータスコードを指定するために、 EntityResponse を提供している。

https://nablarch.github.io/docs/6u2/doc/application_framework/application_framework/web_service/rest/feature_details/resource_signature.html#rest-feature-details-response-header

むしろ修正するなら、`EntityResponse#setContentType`と`@Produces`の両方を指定した時に`BodyConvertHandler`で`@Produces`のみを使用するように促すメッセージの方がよいと考える。