### PR TITLE
マルチパートリクエストのサポート

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,10 +151,10 @@
     </dependency>
 
     <dependency>
-          <groupId>com.nablarch.framework</groupId>
-          <artifactId>nablarch-testing</artifactId>
-          <scope>test</scope>
-      </dependency>
+      <groupId>com.nablarch.framework</groupId>
+      <artifactId>nablarch-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/src/main/java/nablarch/fw/jaxrs/MultipartFormDataBodyConverter.java
+++ b/src/main/java/nablarch/fw/jaxrs/MultipartFormDataBodyConverter.java
@@ -1,0 +1,48 @@
+package nablarch.fw.jaxrs;
+
+import jakarta.ws.rs.core.MediaType;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpResponse;
+
+/**
+ * {@code multipart/form-data}形式のリクエストを後続のハンドラを呼び出すためにPass-Throughする{@link BodyConverter}の実装クラス。
+ */
+public class MultipartFormDataBodyConverter implements BodyConverter {
+    /**
+     * マルチパートリクエストは後続のハンドラで処理するため、処理自体は行わず常に{@code null}を返却する。
+     *
+     * @param request HTTPリクエスト
+     * @param executionContext 実行コンテキスト
+     * @return 常に{@code null}
+     */
+    @Override
+    public Object read(HttpRequest request, ExecutionContext executionContext) {
+        // なにもしない（マルチパートリクエストは後続のハンドラで処理する）
+        return null;
+    }
+
+    /**
+     * マルチパートのメディアタイプがレスポンスとなることはないため、なにもしない
+     *
+     * @param response Beanオブジェクト
+     * @param executionContext 実行コンテキスト
+     * @return 常に{@code null}
+     */
+    @Override
+    public HttpResponse write(Object response, ExecutionContext executionContext) {
+        // なにもしない
+        return null;
+    }
+
+    /**
+     * メディアタイプが{@code multipart/form-data}の場合、後続のハンドラで処理するため{@code true}を返却する
+     *
+     * @param mediaType メディアタイプ
+     * @return メディアタイプが{@code multipart/form-data}の場合は{@code true}
+     */
+    @Override
+    public boolean isConvertible(String mediaType) {
+        return mediaType.startsWith(MediaType.MULTIPART_FORM_DATA);
+    }
+}

--- a/src/main/java/nablarch/fw/jaxrs/MultipartFormDataBodyConverter.java
+++ b/src/main/java/nablarch/fw/jaxrs/MultipartFormDataBodyConverter.java
@@ -23,16 +23,16 @@ public class MultipartFormDataBodyConverter implements BodyConverter {
     }
 
     /**
-     * マルチパートのメディアタイプがレスポンスとなることはないため、なにもしない
+     * マルチパートのメディアタイプがレスポンスとなることはないためサポートしない
      *
      * @param response Beanオブジェクト
      * @param executionContext 実行コンテキスト
-     * @return 常に{@code null}
+     * @return なし
+     * @throws 常に{@link UnsupportedOperationException}をスローする
      */
     @Override
     public HttpResponse write(Object response, ExecutionContext executionContext) {
-        // なにもしない
-        return null;
+        throw new UnsupportedOperationException("multipart/form-data is not supported in response.");
     }
 
     /**
@@ -43,6 +43,6 @@ public class MultipartFormDataBodyConverter implements BodyConverter {
      */
     @Override
     public boolean isConvertible(String mediaType) {
-        return mediaType.startsWith(MediaType.MULTIPART_FORM_DATA);
+        return mediaType.toLowerCase().startsWith("multipart/form-data");
     }
 }

--- a/src/test/java/nablarch/fw/jaxrs/MultipartFormDataBodyConverterTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/MultipartFormDataBodyConverterTest.java
@@ -4,15 +4,21 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class MultipartFormDataBodyConverterTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
     @Test
     public void testMediaType() {
         MultipartFormDataBodyConverter sut = new MultipartFormDataBodyConverter();
 
         // multipart/form-dataで始まるメディアタイプのみtrueとなる
         assertThat(sut.isConvertible("multipart/form-data"), is(true));
+        assertThat(sut.isConvertible("MULTIPART/FORM-DATA"), is(true));
 
         assertThat(sut.isConvertible("multipart"), is(false));
         assertThat(sut.isConvertible("application/json"), is(false));
@@ -20,11 +26,21 @@ public class MultipartFormDataBodyConverterTest {
     }
 
     @Test
-    public void testSerializeDeserialize() {
+    public void testDeserialize() {
         MultipartFormDataBodyConverter sut = new MultipartFormDataBodyConverter();
 
-        // read,writeともになにもせずnullを返す
+        // readはなにもせずnullを返す
         assertThat(sut.read(null, null), nullValue());
-        assertThat(sut.write(null, null), nullValue());
+    }
+
+    @Test
+    public void testSerialize() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("multipart/form-data is not supported in response.");
+
+        MultipartFormDataBodyConverter sut = new MultipartFormDataBodyConverter();
+
+        // writeは例外をスローする
+        sut.write(null, null);
     }
 }

--- a/src/test/java/nablarch/fw/jaxrs/MultipartFormDataBodyConverterTest.java
+++ b/src/test/java/nablarch/fw/jaxrs/MultipartFormDataBodyConverterTest.java
@@ -1,0 +1,30 @@
+package nablarch.fw.jaxrs;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.Test;
+
+public class MultipartFormDataBodyConverterTest {
+    @Test
+    public void testMediaType() {
+        MultipartFormDataBodyConverter sut = new MultipartFormDataBodyConverter();
+
+        // multipart/form-dataで始まるメディアタイプのみtrueとなる
+        assertThat(sut.isConvertible("multipart/form-data"), is(true));
+
+        assertThat(sut.isConvertible("multipart"), is(false));
+        assertThat(sut.isConvertible("application/json"), is(false));
+        assertThat(sut.isConvertible("text/plain"), is(false));
+    }
+
+    @Test
+    public void testSerializeDeserialize() {
+        MultipartFormDataBodyConverter sut = new MultipartFormDataBodyConverter();
+
+        // read,writeともになにもせずnullを返す
+        assertThat(sut.read(null, null), nullValue());
+        assertThat(sut.write(null, null), nullValue());
+    }
+}


### PR DESCRIPTION
# 変更内容

- `multpart/form-data`用の`BodyConverter`の実装を追加
- サポート対象のメディアタイプであることを確認し、`read`はパススルー、`write`はサポート対象外とする実装とした